### PR TITLE
 int_from_bytes is deprecated, use int.from_bytes instead

### DIFF
--- a/jwt/algorithms.py
+++ b/jwt/algorithms.py
@@ -46,7 +46,7 @@ try:
         Ed25519PrivateKey,
         Ed25519PublicKey,
     )
-    from cryptography.utils import int_from_bytes
+    from cryptography.utils import int.from_bytes
 
     has_crypto = True
 except ImportError as e:


### PR DESCRIPTION
fix for deprecation warning 
CryptographyDeprecationWarning: int_from_bytes is deprecated, use int.from_bytes instead

lib/python3.7/site-packages/jwt/algorithms.py:49: CryptographyDeprecationWarning: int_from_bytes is deprecated, use int.from_bytes instead
  from cryptography.utils import int_from_bytes